### PR TITLE
Ignore Pesky macOS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Adds `.DS_Store` to `.gitignore`.