### PR TITLE
Specify python version when creating new environment

### DIFF
--- a/notes/03-tools.md
+++ b/notes/03-tools.md
@@ -43,7 +43,7 @@ docs](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.ht
 
 Now, let's get to environment.  First, let's use conda to create an environment.
 
-    conda create --name csci347
+    conda create --name csci347 python=3.9
 
 And activate the environment
 

--- a/notes/03-tools.md
+++ b/notes/03-tools.md
@@ -43,7 +43,7 @@ docs](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.ht
 
 Now, let's get to environment.  First, let's use conda to create an environment.
 
-    conda create --name csci347 python=3.9
+    conda create --name csci347 python=3.8
 
 And activate the environment
 


### PR DESCRIPTION
When I created the new environment `csci347`, the version of python defaulted to `2.7.18`.

```bash
$ conda create --name test
$ conda activate test
$ python --version
Python 2.7.18
```

> Note: This was on Ubuntu. When I did this on my MacBook pro, it defaulted to `3.9`

The suggested changes in this pull request show how to specify the version of python:

```bash
$ conda create --name csci347 python=3.8
```

... although one could also just upgrade by: `conda install python=X.X`
